### PR TITLE
Notices date fix

### DIFF
--- a/src/components/Dashboard/Views/Licitaciones/Licitacion/Components/Participants.vue
+++ b/src/components/Dashboard/Views/Licitaciones/Licitacion/Components/Participants.vue
@@ -10,7 +10,7 @@
     </stats-card>
     <modal v-if="showParticipants">
       <template slot="header">
-        <h4 class="no-margin">Participantes</h4>
+        <h4 class="no-margin">Proveedores Participantes</h4>
       </template>
       <template slot="body">
         <div class="table-responsive">
@@ -50,7 +50,7 @@
   import LTable from 'src/components/UIComponents/Table.vue'
 
   export default {
-    data() {
+    data () {
       return {
         tableColumns: ['Razón social', 'Email admin proveedor', 'Teléfono admin proveedor'],
         showParticipants: false

--- a/src/components/Dashboard/Views/Licitaciones/Notices/NoticesList.vue
+++ b/src/components/Dashboard/Views/Licitaciones/Notices/NoticesList.vue
@@ -7,7 +7,7 @@
     <div class="list-group" v-for="(notice, index) in notices" :key="index">
       <a class="list-group-item list-group-item-action flex-column align-items-start">
         <p class="mb-1">{{notice.notice}}</p>
-        <small>{{notice.date}}</small>
+        <small>{{formatDate(notice.date)}}</small>
       </a>
     </div>
   </div>
@@ -32,6 +32,20 @@
       },
       beforeMount: function () {
         this.notices = this.bidding.notices.slice().reverse()
+      },
+      methods: {
+        formatDate: (date) => {
+          const dateFormatOptions = {
+            weekday: 'long',
+            year: 'numeric',
+            month: 'long',
+            day: 'numeric',
+            hour: 'numeric',
+            minute: 'numeric'
+          }
+          let stringDate = (new Date(date)).toLocaleDateString('es-ES', dateFormatOptions).replace(',', '')
+          return stringDate.charAt(0).toUpperCase() + stringDate.slice(1)
+        }
       }
     }
 </script>

--- a/src/components/Dashboard/Views/Licitaciones/Notices/PostNoticeParent.vue
+++ b/src/components/Dashboard/Views/Licitaciones/Notices/PostNoticeParent.vue
@@ -41,7 +41,7 @@
        * It gets the date at the moment of publishing the notice, to put it in the bidding.
        */
       setTextActualDate: function () {
-        this.myDate = new Date().toISOString().split('T')[0]
+        this.myDate = new Date()
       },
       /**
        * Event handler for the onUpload event. It calls the postNotice method and it passes the text from the child component.


### PR DESCRIPTION
This branch was created to fix the format of the date from the notices component. Now it follows the standard set in the main tables of the application (showing the day of the week, the month, the year and the time of the Date).
In addition to this, the title of the participants component was fixed from "Participantes" to "Proveedores Participantes".